### PR TITLE
Update tools, dependencies and styles to align more closely with VuFind 9.0.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,14 +11,14 @@ jobs:
       VUFIND_LOCAL_DIR: $GITHUB_WORKSPACE/local
     strategy:
       matrix:
-        php-version: ['7.3', '7.4', '8.0']
+        php-version: ['7.4', '8.0', '8.1']
         include:
-          - php-version: 7.3
-            phing_tasks: "phpunitfast"
           - php-version: 7.4
-            phing_tasks: "phpunitfast phpcs-console php-cs-fixer-dryrun phpstan-console"
+            phing_tasks: "phpunitfast"
           - php-version: 8.0
             phing_tasks: "phpunitfast"
+          - php-version: 8.1
+            phing_tasks: "phpunitfast phpcs-console php-cs-fixer-dryrun phpstan-console"
 
     steps:
       - name: Setup PHP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file, in reverse 
 ### Added
 
 - Nothing.
+
 ### Changed
 
 - The minimum PHP version requirement has been raised to 7.4.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## Next Release - TBD
+
+### Added
+
+- Nothing.
+### Changed
+
+- The minimum PHP version requirement has been raised to 7.4.1.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 4.1.0 - 2021-06-07
 
 ### Added

--- a/build.xml
+++ b/build.xml
@@ -5,7 +5,7 @@
   <property name="builddir" value="${tmp}/build/${phing.project.name}" override="true" />
   <property name="srcdir"   value="${project.basedir}" override="true" />
   <property name="skip_phpdoc" value="false" />
-  <property name="phpdoc_version" value="3.0.0" />
+  <property name="phpdoc_version" value="3.3.1" />
 
   <!-- Main Target -->
   <target name="main" description="main target">

--- a/composer.json
+++ b/composer.json
@@ -15,24 +15,24 @@
     },
     "config": {
         "platform": {
-            "php": "7.3"
+            "php": "7.4.1"
         }
     },
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.4.1",
         "laminas/laminas-http": ">=2.2",
         "symfony/console": "^4.0||^5.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "2.19.0",
+        "friendsofphp/php-cs-fixer": "3.8.0",
         "pear/http_request2": "2.4.2",
         "phploc/phploc": "7.0.2",
-        "phpmd/phpmd": "2.10.0",
-        "phpstan/phpstan": "0.12.85",
-        "phpunit/phpunit": "9.5.4",
-        "phing/phing": "2.16.4",
+        "phpmd/phpmd": "2.12.0",
+        "phpstan/phpstan": "1.6.8",
+        "phpunit/phpunit": "9.5.20",
+        "phing/phing": "2.17.3",
         "sebastian/phpcpd": "6.0.3",
-        "squizlabs/php_codesniffer": "3.6.0"
+        "squizlabs/php_codesniffer": "3.6.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Exception/OaiException.php
+++ b/src/Exception/OaiException.php
@@ -62,7 +62,10 @@ class OaiException extends \RuntimeException
      * @param int        $code       Error code
      * @param ?Throwable $previous   Previous exception
      */
-    public function __construct(string $oaiCode, string $oaiMessage, int $code = 0,
+    public function __construct(
+        string $oaiCode,
+        string $oaiMessage,
+        int $code = 0,
         ?Throwable $previous = null
     ) {
         $this->oaiCode = $oaiCode;

--- a/src/OaiPmh/Communicator.php
+++ b/src/OaiPmh/Communicator.php
@@ -73,7 +73,9 @@ class Communicator
      * @param Client                     $client    HTTP client
      * @param ResponseProcessorInterface $processor Response processor (optional)
      */
-    public function __construct($uri, Client $client,
+    public function __construct(
+        $uri,
+        Client $client,
         ResponseProcessorInterface $processor = null
     ) {
         $this->baseUrl = $uri;

--- a/src/OaiPmh/Harvester.php
+++ b/src/OaiPmh/Harvester.php
@@ -107,8 +107,11 @@ class Harvester
      * @param StateManager $stateManager State manager
      * @param array        $settings     OAI-PMH settings
      */
-    public function __construct(Communicator $communicator, RecordWriter $writer,
-        StateManager $stateManager, $settings = []
+    public function __construct(
+        Communicator $communicator,
+        RecordWriter $writer,
+        StateManager $stateManager,
+        $settings = []
     ) {
         // Don't time out during harvest!!
         set_time_limit(0);
@@ -185,7 +188,9 @@ class Harvester
             } else {
                 // ...otherwise, start harvesting at the requested date:
                 $token = $this->getRecordsByDate(
-                    $this->startDate, $set, $this->harvestEndDate
+                    $this->startDate,
+                    $set,
+                    $this->harvestEndDate
                 );
             }
 

--- a/src/OaiPmh/HarvesterCommand.php
+++ b/src/OaiPmh/HarvesterCommand.php
@@ -96,8 +96,12 @@ class HarvesterCommand extends Command
      * @param string|null      $name        The name of the command; passing null
      * means it must be set in configure()
      */
-    public function __construct($client = null, $harvestRoot = null,
-        HarvesterFactory $factory = null, $silent = false, $name = null
+    public function __construct(
+        $client = null,
+        $harvestRoot = null,
+        HarvesterFactory $factory = null,
+        $silent = false,
+        $name = null
     ) {
         $this->client = $client ?: new Client();
         $this->harvestRoot = $harvestRoot ?: getcwd();
@@ -282,7 +286,8 @@ class HarvesterCommand extends Command
      *
      * @return array
      */
-    protected function updateSettingsWithConsoleOptions(InputInterface $input,
+    protected function updateSettingsWithConsoleOptions(
+        InputInterface $input,
         $settings
     ) {
         $directMapSettings = [
@@ -336,7 +341,8 @@ class HarvesterCommand extends Command
         $processed = $skipped = $errors = 0;
         foreach ($allSettings as $target => $baseSettings) {
             $settings = $this->updateSettingsWithConsoleOptions(
-                $input, $baseSettings
+                $input,
+                $baseSettings
             );
             if (empty($target) || empty($settings)) {
                 $skipped++;
@@ -458,8 +464,11 @@ class HarvesterCommand extends Command
      * @return void
      * @throws \Exception
      */
-    protected function harvestSingleRepository(InputInterface $input,
-        OutputInterface $output, $target, $settings
+    protected function harvestSingleRepository(
+        InputInterface $input,
+        OutputInterface $output,
+        $target,
+        $settings
     ) {
         $settings['from'] = $input->getOption('from');
         $settings['until'] = $input->getOption('until');

--- a/src/OaiPmh/HarvesterFactory.php
+++ b/src/OaiPmh/HarvesterFactory.php
@@ -154,8 +154,11 @@ class HarvesterFactory
      *
      * @return Communicator
      */
-    protected function getCommunicator(Client $client, array $settings,
-        ResponseProcessorInterface $processor, $target,
+    protected function getCommunicator(
+        Client $client,
+        array $settings,
+        ResponseProcessorInterface $processor,
+        $target,
         OutputInterface $output = null
     ) {
         if (empty($settings['url'])) {
@@ -181,7 +184,9 @@ class HarvesterFactory
      *
      * @return RecordXmlFormatter
      */
-    protected function getFormatter(Communicator $communicator, array $settings,
+    protected function getFormatter(
+        Communicator $communicator,
+        array $settings,
         OutputInterface $output = null
     ) {
         // Build the formatter:
@@ -262,8 +267,10 @@ class HarvesterFactory
      *
      * @return RecordWriter
      */
-    protected function getWriter(RecordWriterStrategyInterface $strategy,
-        RecordXmlFormatter $formatter, array $settings
+    protected function getWriter(
+        RecordWriterStrategyInterface $strategy,
+        RecordXmlFormatter $formatter,
+        array $settings
     ) {
         return new RecordWriter($strategy, $formatter, $settings);
     }
@@ -292,14 +299,21 @@ class HarvesterFactory
      *
      * @throws \Exception
      */
-    public function getHarvester($target, $harvestRoot, Client $client = null,
-        array $settings = [], OutputInterface $output = null
+    public function getHarvester(
+        $target,
+        $harvestRoot,
+        Client $client = null,
+        array $settings = [],
+        OutputInterface $output = null
     ) {
         $basePath = $this->getBasePath($harvestRoot, $target);
         $responseProcessor = $this->getResponseProcessor($basePath, $settings);
         $communicator = $this->getCommunicator(
             $this->configureClient($client, $settings),
-            $settings, $responseProcessor, $target, $output
+            $settings,
+            $responseProcessor,
+            $target,
+            $output
         );
         $formatter = $this->getFormatter($communicator, $settings, $output);
         $strategy = $this->getWriterStrategyFactory()

--- a/src/OaiPmh/RecordXmlFormatter.php
+++ b/src/OaiPmh/RecordXmlFormatter.php
@@ -242,7 +242,8 @@ class RecordXmlFormatter
         $attributes = [];
         preg_match_all(
             '/(^| )([^"]*"?[^"]*"|[^\']*\'?[^\']*\')/',
-            $extractedNs[1], $attributes
+            $extractedNs[1],
+            $attributes
         );
         $extractedAttributes = '';
         foreach ($attributes[0] as $attribute) {
@@ -309,7 +310,9 @@ class RecordXmlFormatter
         // Build the final record:
         return trim(
             $this->fixNamespaces(
-                $xml, $recordObj->getDocNamespaces(), $metadataAttributes
+                $xml,
+                $recordObj->getDocNamespaces(),
+                $metadataAttributes
             )
         );
     }

--- a/src/RecordWriterStrategy/CombinedRecordWriterStrategy.php
+++ b/src/RecordWriterStrategy/CombinedRecordWriterStrategy.php
@@ -148,7 +148,8 @@ class CombinedRecordWriterStrategy extends AbstractRecordWriterStrategy
     {
         if (false !== $this->firstHarvestedId) {
             $this->saveFile(
-                $this->firstHarvestedId, $this->getCombinedXML($this->innerXML)
+                $this->firstHarvestedId,
+                $this->getCombinedXML($this->innerXML)
             );
         }
 

--- a/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
+++ b/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
@@ -92,12 +92,16 @@ class HarvesterFactoryTest extends \PHPUnit\Framework\TestCase
             'dateGranularity' => 'mygranularity',
         ];
         $oai = $this->getHarvester(
-            'test', sys_get_temp_dir(), $config, $this->getMockClient()
+            'test',
+            sys_get_temp_dir(),
+            $config,
+            $this->getMockClient()
         );
 
         // Special cases where config key != class property:
         $this->assertEquals(
-            $config['dateGranularity'], $this->getProperty($oai, 'granularity')
+            $config['dateGranularity'],
+            $this->getProperty($oai, 'granularity')
         );
         unset($config['dateGranularity']);
         unset($config['url']);
@@ -133,13 +137,15 @@ class HarvesterFactoryTest extends \PHPUnit\Framework\TestCase
         $writer = $this->getProperty($oai, 'writer');
         $formatter = $this->getProperty($writer, 'recordFormatter');
         $this->assertEquals(
-            $config['injectSetName'], $this->getProperty($formatter, 'injectSetName')
+            $config['injectSetName'],
+            $this->getProperty($formatter, 'injectSetName')
         );
         $this->assertEquals(
             [
                 'Audio (Music)' => 'Audio (Music)',
                 'Audio (Non-Music)' => 'Audio (Non-Music)'
-            ], $this->getProperty($formatter, 'setNames')
+            ],
+            $this->getProperty($formatter, 'setNames')
         );
     }
 
@@ -182,7 +188,8 @@ class HarvesterFactoryTest extends \PHPUnit\Framework\TestCase
         ];
         $oai = $this->getHarvester('test', sys_get_temp_dir(), $config, $client);
         $this->assertEquals(
-            'YYYY-MM-DDThh:mm:ssZ', $this->getProperty($oai, 'granularity')
+            'YYYY-MM-DDThh:mm:ssZ',
+            $this->getProperty($oai, 'granularity')
         );
     }
 
@@ -219,7 +226,8 @@ class HarvesterFactoryTest extends \PHPUnit\Framework\TestCase
         ];
         $oai = $this->getHarvester('test', sys_get_temp_dir(), $config, $client);
         $this->assertEquals(
-            'YYYY-MM-DDThh:mm:ssZ', $this->getProperty($oai, 'granularity')
+            'YYYY-MM-DDThh:mm:ssZ',
+            $this->getProperty($oai, 'granularity')
         );
     }
 

--- a/tests/unit-tests/src/VuFindTest/Exception/OaiExceptionTest.php
+++ b/tests/unit-tests/src/VuFindTest/Exception/OaiExceptionTest.php
@@ -52,7 +52,8 @@ class OaiExceptionTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('code', $exception->getOaiCode());
         $this->assertEquals('message', $exception->getOaiMessage());
         $this->assertEquals(
-            'OAI-PMH error -- code: code, value: message', $exception->getMessage()
+            'OAI-PMH error -- code: code, value: message',
+            $exception->getMessage()
         );
         $this->assertEquals(0, $exception->getCode());
         $this->assertNull($exception->getPrevious());

--- a/tests/unit-tests/src/VuFindTest/OaiPmh/HarvesterCommandTest.php
+++ b/tests/unit-tests/src/VuFindTest/OaiPmh/HarvesterCommandTest.php
@@ -160,8 +160,10 @@ class HarvesterCommandTest extends \PHPUnit\Framework\TestCase
         $factory->expects($this->once())
             ->method('getHarvester')
             ->with(
-                $this->equalTo('foo'), $this->equalTo($basePath),
-                $this->equalTo($client), $this->equalTo($expectedSettings)
+                $this->equalTo('foo'),
+                $this->equalTo($basePath),
+                $this->equalTo($client),
+                $this->equalTo($expectedSettings)
             )
             ->will($this->returnValue($harvester));
         $ini = realpath(__DIR__ . '/../../../../fixtures/test.ini');
@@ -252,8 +254,10 @@ class HarvesterCommandTest extends \PHPUnit\Framework\TestCase
         $factory->expects($this->once())
             ->method('getHarvester')
             ->with(
-                $this->equalTo('foo'), $this->equalTo($basePath),
-                $this->equalTo($client), $this->equalTo($expectedSettings)
+                $this->equalTo('foo'),
+                $this->equalTo($basePath),
+                $this->equalTo($client),
+                $this->equalTo($expectedSettings)
             )
             ->will($this->returnValue($harvester));
         $ini = realpath(__DIR__ . '/../../../../fixtures/test.ini');

--- a/tests/unit-tests/src/VuFindTest/OaiPmh/HarvesterTest.php
+++ b/tests/unit-tests/src/VuFindTest/OaiPmh/HarvesterTest.php
@@ -134,8 +134,11 @@ class HarvesterTest extends \PHPUnit\Framework\TestCase
      *
      * @return Harvester
      */
-    protected function getHarvester($settings = [], $communicator = null,
-        $writer = null, $stateManager = null
+    protected function getHarvester(
+        $settings = [],
+        $communicator = null,
+        $writer = null,
+        $stateManager = null
     ) {
         return new Harvester(
             $communicator ?: $this->getMockCommunicator(),
@@ -275,7 +278,8 @@ XML;
             );
         $harvester = $this->getHarvester([], $comm);
         $this->assertEquals(
-            'YYYY-MM-DDThh:mm:ssZ', $this->getProperty($harvester, 'granularity')
+            'YYYY-MM-DDThh:mm:ssZ',
+            $this->getProperty($harvester, 'granularity')
         );
     }
 
@@ -300,7 +304,10 @@ XML;
         $sm->expects($this->once())->method('saveDate')
             ->with($this->equalTo('2016-07-13T14:26:22Z'));
         $harvester = $this->getHarvester(
-            ['dateGranularity' => 'YYYY-MM-DDThh:mm:ssZ'], $comm, $writer, $sm
+            ['dateGranularity' => 'YYYY-MM-DDThh:mm:ssZ'],
+            $comm,
+            $writer,
+            $sm
         );
         $harvester->launch();
     }
@@ -339,7 +346,9 @@ XML;
                 'set' => 'xyzzy', 'dateGranularity' => 'YYYY-MM-DDThh:mm:ssZ',
                 'from' => '2016-07-01', 'until' => '2016-07-31',
             ],
-            $comm, $writer, $sm
+            $comm,
+            $writer,
+            $sm
         );
         $harvester->launch();
     }
@@ -369,7 +378,10 @@ XML;
             ->will($this->returnValue([null, 'foo', 'bar']));
         $sm->expects($this->once())->method('clearState');
         $harvester = $this->getHarvester(
-            ['dateGranularity' => 'YYYY-MM-DDThh:mm:ssZ'], $comm, null, $sm
+            ['dateGranularity' => 'YYYY-MM-DDThh:mm:ssZ'],
+            $comm,
+            null,
+            $sm
         );
         $harvester->launch();
     }
@@ -395,7 +407,8 @@ XML;
                 )
             );
         $harvester = $this->getHarvester(
-            ['dateGranularity' => 'YYYY-MM-DDThh:mm:ssZ'], $comm
+            ['dateGranularity' => 'YYYY-MM-DDThh:mm:ssZ'],
+            $comm
         );
         $harvester->launch();
     }

--- a/tests/unit-tests/src/VuFindTest/OaiPmh/RecordWriterTest.php
+++ b/tests/unit-tests/src/VuFindTest/OaiPmh/RecordWriterTest.php
@@ -94,7 +94,8 @@ class RecordWriterTest extends \PHPUnit\Framework\TestCase
      *
      * @return RecordWriter
      */
-    protected function getWriter(array $config = [],
+    protected function getWriter(
+        array $config = [],
         RecordWriterStrategyInterface $strategy = null,
         RecordXmlFormatter $formatter = null
     ) {

--- a/tests/unit-tests/src/VuFindTest/OaiPmh/RecordXmlFormatterTest.php
+++ b/tests/unit-tests/src/VuFindTest/OaiPmh/RecordXmlFormatterTest.php
@@ -129,7 +129,8 @@ class RecordXmlFormatterTest extends \PHPUnit\Framework\TestCase
         $result = $formatter->format('foo', $this->getRecordFromFixture());
         $xml = simplexml_load_string($result);
         $this->assertEquals(
-            'oai:urm_publish:9925821506101791', (string)$xml->identifier
+            'oai:urm_publish:9925821506101791',
+            (string)$xml->identifier
         );
     }
 
@@ -222,7 +223,8 @@ class RecordXmlFormatterTest extends \PHPUnit\Framework\TestCase
     {
         $formatter = new RecordXmlFormatter();
         $result = $formatter->format(
-            'foo', $this->getRecordFromFixture('oai_doaj.xml')
+            'foo',
+            $this->getRecordFromFixture('oai_doaj.xml')
         );
         $xml = simplexml_load_string($result);
         $this->assertTrue(is_object($xml));


### PR DESCRIPTION
While I'm refreshing tools, it seemed like a good idea to take care of vufindharvest as well, since we'll need to be up to date when #8 is ready for merging. Note that all the code changes are simply related to changes in php-cs-fixer defaults.