### PR TITLE
Refactor communicator tests

### DIFF
--- a/tests/unit-tests/src/VuFindTest/OaiPmh/CommunicatorTest.php
+++ b/tests/unit-tests/src/VuFindTest/OaiPmh/CommunicatorTest.php
@@ -29,9 +29,9 @@
 namespace VuFindTest\Harvest\OaiPmh;
 
 use Laminas\Http\Client;
-use VuFindHarvest\OaiPmh\Communicator;
 use Symfony\Component\Console\Output\OutputInterface;
 use VuFindHarvest\ConsoleOutput\ConsoleWriter;
+use VuFindHarvest\OaiPmh\Communicator;
 
 /**
  * OAI-PMH communicator test.
@@ -44,7 +44,6 @@ use VuFindHarvest\ConsoleOutput\ConsoleWriter;
  */
 class CommunicatorTest extends \PHPUnit\Framework\TestCase
 {
-
     /**
      * Get Communicator
      *

--- a/tests/unit-tests/src/VuFindTest/OaiPmh/CommunicatorTest.php
+++ b/tests/unit-tests/src/VuFindTest/OaiPmh/CommunicatorTest.php
@@ -22,6 +22,7 @@
  *
  * @category VuFind
  * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
  * @author   Ryan Jacobs <rjacobs@crl.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development


### PR DESCRIPTION
This is a follow-up to Issue #7 that surfaced in the related PR #8.

In #8 some refactoring was required, which also led to test modifications. While addressing this we discovered that several tests that provide coverage for VuFindHarvest\OaiPmh\Communicator were problematically declared inside HarvesterFactoryTest. HarvesterFactoryTest was serving as a basis for these tests as new Harvester objects originally made Communicator calls via their constructor. PR #8 removes those constructor calls, and thus breaks the related tests. This follow addresses this by:

1. Moving tests that center on Communicator logic from HarvesterFactoryTest into a new CommunicatorTest class.
2. Restoring Communicator coverage temporarily removed during #8.

While this is a direct follow-up to #8 it is not strictly dependent on that PR. The new Communicator tests here should pass both before and after a merge on #8.