### PR TITLE
Extract namespaces from <record> as well as <metadata>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## Next Release - TBD
+
+### Added
+
+- Nothing
+
+### Changed
+
+- The protected VuFindHarvest\OaiPmh\RecordXmlFormatter::extractMetadataAttributes() method has been replaced with a more general-purpose extractHigherLevelAttributes() method.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Records with namespace declarations in the <record> tag instead of the <metadata> tag will now have appropriate namespaces applied to the extracted XML.
+
 ## 5.1.0 - 2023-02-28
 
 ### Added

--- a/src/OaiPmh/RecordXmlFormatter.php
+++ b/src/OaiPmh/RecordXmlFormatter.php
@@ -237,8 +237,11 @@ class RecordXmlFormatter
      *
      * @return array
      */
-    protected function extractHigherLevelAttributes($raw, $tagName, $record)
-    {
+    protected function extractHigherLevelAttributes(
+        string $raw,
+        string $tagName,
+        string $record
+    ): array {
         // remove all attributes from extractedNs that appear deeper in xml; this
         // helps prevent fatal errors caused by the same namespace declaration
         // appearing twice in a single tag.

--- a/tests/fixtures/subjectsplus.xml
+++ b/tests/fixtures/subjectsplus.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>2023-03-30T16:02:12+05:45</responseDate>
+  <request verb="ListRecords">http:http://182.93.84.135/sp1/oai/oai.php</request>
+  <ListRecords><record xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <header>
+    <identifier>1</identifier>
+    <datestamp>2023-03-30</datestamp>
+  </header>
+  <metadata>
+    <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+      <dc:title>General</dc:title>
+      <dc:creator>Super Admin</dc:creator>
+      <dc:date>2011-03-26 19:16:19</dc:date>
+      <dc:format>text/html</dc:format>
+      <dc:language>English</dc:language>
+      <dc:publisher>HealthNet Nepal</dc:publisher>
+      <dc:type>InteractiveResource</dc:type>
+      <dc:description/>
+      <dc:identifier>http:http://182.93.84.135/sp1/subjects/guide.php?id=1</dc:identifier>
+    </oai_dc:dc>
+  </metadata>
+</record>
+</ListRecords>
+</OAI-PMH>

--- a/tests/unit-tests/src/VuFindTest/OaiPmh/RecordXmlFormatterTest.php
+++ b/tests/unit-tests/src/VuFindTest/OaiPmh/RecordXmlFormatterTest.php
@@ -231,6 +231,26 @@ class RecordXmlFormatterTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test that a record with namespace declarations in the <record> tab (as seen in
+     * SubjectsPlus, for example) is processed correctly.
+     *
+     * @return void
+     */
+    public function testNamespaceInsertionFromRecordTag()
+    {
+        $formatter = new RecordXmlFormatter();
+        $result = $formatter->format(
+            'foo',
+            $this->getRecordFromFixture('subjectsplus.xml')
+        );
+        $xml = simplexml_load_string($result);
+        $this->assertEquals(
+            'http://www.openarchives.org/OAI/2.0/oai_dc/',
+            $xml->getNamespaces()['oai_dc']
+        );
+    }
+
+    /**
      * Get a record from the test fixture.
      *
      * @param string $fixture Filename of fixture (inside fixture directory).


### PR DESCRIPTION
@livedvd discovered a bug in the OAI-PMH harvester -- when extracting records, if namespaces are defined in the `<record>` tag of the OAI response instead of the `<metadata>` tag, the resulting XML is missing namespace declarations and is thus invalid. This PR fixes the problem. This situation arises when harvesting metadata from SubjectsPlus.