### PR TITLE
Use annotations for forward-compatibility with Symfony/Console 7.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- Compatibility with Symfony/Console versions 6 and 7.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Removed
 
-- Nothing.
+- Compatibility with Symfony/Console versions less than 5.3.
 
 ## Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=8.0",
         "laminas/laminas-http": ">=2.2",
-        "symfony/console": "^4.0||^5.0"
+        "symfony/console": "^5.3||^6||^7"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "3.26.1",

--- a/src/OaiPmh/HarvesterCommand.php
+++ b/src/OaiPmh/HarvesterCommand.php
@@ -30,6 +30,7 @@
 namespace VuFindHarvest\OaiPmh;
 
 use Laminas\Http\Client;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -48,6 +49,10 @@ use VuFindHarvest\Exception\OaiException;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/indexing:oai-pmh Wiki
  */
+#[AsCommand(
+    name: 'harvest/harvest_oai',
+    description: 'OAI-PMH harvester'
+)]
 class HarvesterCommand extends Command
 {
     use WriterAwareTrait;
@@ -122,7 +127,6 @@ class HarvesterCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('OAI-PMH harvester')
             ->setHelp('Harvests metadata using the OAI-PMH protocol.')
             ->addArgument(
                 'target',


### PR DESCRIPTION
Symfony/Console 6 deprecates the $defaultName property, which is removed in Symfony/Console 7. This PR updates the project for forward-compatibility and drops support for very old versions of Symfony/Console that are no longer compatible.