### PR TITLE
HarvesterFactory: use Laminas Proxy adapter to allow connections over a proxy

### DIFF
--- a/etc/oai.ini
+++ b/etc/oai.ini
@@ -29,6 +29,11 @@
 ; httpUser = myUsername
 ; httpPass = myPassword
 ; stopAfter = 100
+; proxy_host = "my.proxy.host"
+; proxy_port = 8080
+; proxy_user = "alice"
+; proxy_pass = "proxyPassword"
+; proxy_auth = "Laminas\Http\Client::AUTH_BASIC"
 ;
 ; The section_name may be passed to harvest_oai.php as a parameter to harvest only
 ; records from that source.  This is also the directory name that records will be
@@ -146,6 +151,10 @@
 ; stopAfter may be set to a natural positive number 'n' in order to stop harvesting
 ; after just the first 'n' records have been harvested. This option can be used for
 ; testing purposes. It allows the harvesting of smaller data sets.
+;
+; proxy_* settings allow to use an HTTP proxy. For the details see the corresponding
+; Laminas documentation on 
+; https://docs.laminas.dev/laminas-http/client/adapters/#the-proxy-adapter
 ;
 ; SAMPLE CONFIGURATION FOR OPEN JOURNAL SYSTEMS
 ;[OJS]

--- a/src/OaiPmh/HarvesterFactory.php
+++ b/src/OaiPmh/HarvesterFactory.php
@@ -184,7 +184,8 @@ class HarvesterFactory
         $comm = new Communicator($settings['url'], $client, $processor);
         // We only want the communicator to output messages if we are in verbose
         // mode; communicator messages are considered verbose output.
-        if (($settings['verbose'] ?? false)
+        if (
+            ($settings['verbose'] ?? false)
             && $writer = $this->getConsoleWriter($output, $settings)
         ) {
             $comm->setOutputWriter($writer);

--- a/src/OaiPmh/HarvesterFactory.php
+++ b/src/OaiPmh/HarvesterFactory.php
@@ -30,6 +30,7 @@
 namespace VuFindHarvest\OaiPmh;
 
 use Laminas\Http\Client;
+use Laminas\Http\Client\Adapter\Proxy;
 use Symfony\Component\Console\Output\OutputInterface;
 use VuFindHarvest\ConsoleOutput\ConsoleWriter;
 use VuFindHarvest\RecordWriterStrategy\RecordWriterStrategyFactory;
@@ -50,6 +51,14 @@ use VuFindHarvest\ResponseProcessor\SimpleXmlResponseProcessor;
  */
 class HarvesterFactory
 {
+    const PROXY_SETTINGS = [
+        'proxy_host',
+        'proxy_port',
+        'proxy_user',
+        'proxy_pass',
+        'proxy_auth'
+    ];
+
     /**
      * Add SSL options to $options if standard files can be autodetected.
      *
@@ -80,6 +89,7 @@ class HarvesterFactory
     {
         $options = [
             'timeout' => $settings['timeout'] ?? 60,
+            'adapter' => Proxy::class,
         ];
         if (isset($settings['autosslca']) && $settings['autosslca']) {
             $this->addAutoSslOptions($options);
@@ -91,6 +101,11 @@ class HarvesterFactory
         }
         if (isset($settings['sslverifypeer']) && !$settings['sslverifypeer']) {
             $options['sslverifypeer'] = false;
+        }
+        foreach (self::PROXY_SETTINGS as $proxySetting) {
+            if (isset($settings[$proxySetting])) {
+                $options[$proxySetting] = $settings[$proxySetting];
+            }
         }
         return $options;
     }

--- a/src/OaiPmh/HarvesterFactory.php
+++ b/src/OaiPmh/HarvesterFactory.php
@@ -140,7 +140,7 @@ class HarvesterFactory
      *
      * @param string $harvestRoot Root directory containing harvested data.
      * @param string $target      The OAI-PMH target directory to create inside
-     *                            $harvestRoot.
+     * $harvestRoot.
      *
      * @return string
      */
@@ -166,7 +166,7 @@ class HarvesterFactory
      * @param array                      $settings  Additional settings
      * @param ResponseProcessorInterface $processor Response processor
      * @param string                     $target    Target being configured (used for
-     *                                              error messages)
+     * error messages)
      * @param OutputInterface            $output    Output interface
      *
      * @return Communicator
@@ -307,7 +307,7 @@ class HarvesterFactory
      * Get the harvester
      *
      * @param string          $target      Name of source being harvested (used as
-     *                                     directory name for storing harvested data inside $harvestRoot)
+     * directory name for storing harvested data inside $harvestRoot)
      * @param string          $harvestRoot Root directory containing harvested data.
      * @param Client          $client      HTTP client
      * @param array           $settings    Additional settings

--- a/src/OaiPmh/HarvesterFactory.php
+++ b/src/OaiPmh/HarvesterFactory.php
@@ -89,7 +89,6 @@ class HarvesterFactory
     {
         $options = [
             'timeout' => $settings['timeout'] ?? 60,
-            'adapter' => Proxy::class,
         ];
         if (isset($settings['autosslca']) && $settings['autosslca']) {
             $this->addAutoSslOptions($options);
@@ -106,6 +105,9 @@ class HarvesterFactory
             if (isset($settings[$proxySetting])) {
                 $options[$proxySetting] = $settings[$proxySetting];
             }
+        }
+        if (!empty($settings['proxy_host'])) {
+            $options['adapter'] = Proxy::class;
         }
         return $options;
     }

--- a/src/OaiPmh/HarvesterFactory.php
+++ b/src/OaiPmh/HarvesterFactory.php
@@ -51,7 +51,7 @@ use VuFindHarvest\ResponseProcessor\SimpleXmlResponseProcessor;
  */
 class HarvesterFactory
 {
-    const PROXY_SETTINGS = [
+    protected const PROXY_SETTINGS = [
         'proxy_host',
         'proxy_port',
         'proxy_user',
@@ -140,7 +140,7 @@ class HarvesterFactory
      *
      * @param string $harvestRoot Root directory containing harvested data.
      * @param string $target      The OAI-PMH target directory to create inside
-     * $harvestRoot.
+     *                            $harvestRoot.
      *
      * @return string
      */
@@ -166,7 +166,7 @@ class HarvesterFactory
      * @param array                      $settings  Additional settings
      * @param ResponseProcessorInterface $processor Response processor
      * @param string                     $target    Target being configured (used for
-     * error messages)
+     *                                              error messages)
      * @param OutputInterface            $output    Output interface
      *
      * @return Communicator
@@ -184,8 +184,7 @@ class HarvesterFactory
         $comm = new Communicator($settings['url'], $client, $processor);
         // We only want the communicator to output messages if we are in verbose
         // mode; communicator messages are considered verbose output.
-        if (
-            ($settings['verbose'] ?? false)
+        if (($settings['verbose'] ?? false)
             && $writer = $this->getConsoleWriter($output, $settings)
         ) {
             $comm->setOutputWriter($writer);
@@ -307,7 +306,7 @@ class HarvesterFactory
      * Get the harvester
      *
      * @param string          $target      Name of source being harvested (used as
-     * directory name for storing harvested data inside $harvestRoot)
+     *                                     directory name for storing harvested data inside $harvestRoot)
      * @param string          $harvestRoot Root directory containing harvested data.
      * @param Client          $client      HTTP client
      * @param array           $settings    Additional settings

--- a/src/OaiPmh/HarvesterFactory.php
+++ b/src/OaiPmh/HarvesterFactory.php
@@ -56,7 +56,7 @@ class HarvesterFactory
         'proxy_port',
         'proxy_user',
         'proxy_pass',
-        'proxy_auth'
+        'proxy_auth',
     ];
 
     /**

--- a/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
+++ b/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
@@ -164,8 +164,8 @@ class HarvesterFactoryTest extends \PHPUnit\Framework\TestCase
             ->with(
                 $this->equalTo(
                     [
-                    'sslverifypeer' => false, 
-                    'timeout' => 60, 
+                    'sslverifypeer' => false,
+                    'timeout' => 60,
                     'adapter' => \Laminas\Http\Client\Adapter\Proxy::class
                     ]
                 )
@@ -191,7 +191,7 @@ class HarvesterFactoryTest extends \PHPUnit\Framework\TestCase
             ->with(
                 $this->equalTo(
                     [
-                    'timeout' => 60, 
+                    'timeout' => 60,
                     'adapter' => \Laminas\Http\Client\Adapter\Proxy::class,
                     'proxy_host' => 'http://proxy.host',
                     'proxy_port' => 8080,

--- a/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
+++ b/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
@@ -186,7 +186,7 @@ class HarvesterFactoryTest extends \PHPUnit\Framework\TestCase
             ->method('setOptions')
             ->with($this->equalTo([
                 'timeout' => 60, 
-                'adapter' => 'Laminas\Http\Client\Adapter\Proxy',
+                'adapter' => \Laminas\Http\Client\Adapter\Proxy::class,
                 'proxy_host' => 'http://proxy.host',
                 'proxy_port' => 8080,
                 'proxy_user' => 'alice',

--- a/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
+++ b/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
@@ -166,7 +166,7 @@ class HarvesterFactoryTest extends \PHPUnit\Framework\TestCase
                     [
                     'sslverifypeer' => false,
                     'timeout' => 60,
-                    'adapter' => \Laminas\Http\Client\Adapter\Proxy::class
+                    'adapter' => \Laminas\Http\Client\Adapter\Proxy::class,
                     ]
                 )
             );
@@ -197,7 +197,7 @@ class HarvesterFactoryTest extends \PHPUnit\Framework\TestCase
                     'proxy_port' => 8080,
                     'proxy_user' => 'alice',
                     'proxy_pass' => 'foobar',
-                    'proxy_auth' => \Laminas\Http\Client::AUTH_BASIC
+                    'proxy_auth' => \Laminas\Http\Client::AUTH_BASIC,
                     ]
                 )
             );
@@ -208,7 +208,7 @@ class HarvesterFactoryTest extends \PHPUnit\Framework\TestCase
             'proxy_port' => 8080,
             'proxy_user' => 'alice',
             'proxy_pass' => 'foobar',
-            'proxy_auth' => \Laminas\Http\Client::AUTH_BASIC
+            'proxy_auth' => \Laminas\Http\Client::AUTH_BASIC,
         ];
         $this->getHarvester('test', sys_get_temp_dir(), $config, $client);
     }

--- a/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
+++ b/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
@@ -164,7 +164,7 @@ class HarvesterFactoryTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo([
                 'sslverifypeer' => false, 
                 'timeout' => 60, 
-                'adapter' => 'Laminas\Http\Client\Adapter\Proxy'
+                'adapter' => \Laminas\Http\Client\Adapter\Proxy::class
             ]));
         $config = [
             'url' => 'http://localhost',

--- a/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
+++ b/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
@@ -164,9 +164,9 @@ class HarvesterFactoryTest extends \PHPUnit\Framework\TestCase
             ->with(
                 $this->equalTo(
                     [
-                    'sslverifypeer' => false,
-                    'timeout' => 60,
-                    'adapter' => \Laminas\Http\Client\Adapter\Proxy::class,
+                        'sslverifypeer' => false,
+                        'timeout' => 60,
+                        'adapter' => \Laminas\Http\Client\Adapter\Proxy::class,
                     ]
                 )
             );
@@ -191,13 +191,13 @@ class HarvesterFactoryTest extends \PHPUnit\Framework\TestCase
             ->with(
                 $this->equalTo(
                     [
-                    'timeout' => 60,
-                    'adapter' => \Laminas\Http\Client\Adapter\Proxy::class,
-                    'proxy_host' => 'http://proxy.host',
-                    'proxy_port' => 8080,
-                    'proxy_user' => 'alice',
-                    'proxy_pass' => 'foobar',
-                    'proxy_auth' => \Laminas\Http\Client::AUTH_BASIC,
+                        'timeout' => 60,
+                        'adapter' => \Laminas\Http\Client\Adapter\Proxy::class,
+                        'proxy_host' => 'http://proxy.host',
+                        'proxy_port' => 8080,
+                        'proxy_user' => 'alice',
+                        'proxy_pass' => 'foobar',
+                        'proxy_auth' => \Laminas\Http\Client::AUTH_BASIC,
                     ]
                 )
             );

--- a/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
+++ b/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
@@ -166,7 +166,6 @@ class HarvesterFactoryTest extends \PHPUnit\Framework\TestCase
                     [
                         'sslverifypeer' => false,
                         'timeout' => 60,
-                        'adapter' => \Laminas\Http\Client\Adapter\Proxy::class,
                     ]
                 )
             );

--- a/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
+++ b/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
@@ -67,7 +67,7 @@ class HarvesterFactoryTest extends \PHPUnit\Framework\TestCase
      * Get harvester
      *
      * @param string $target      Name of source being harvested (used as directory
-     * name for storing harvested data inside $harvestRoot)
+     *                            name for storing harvested data inside $harvestRoot)
      * @param string $harvestRoot Root directory containing harvested data.
      * @param array  $config      Additional settings
      * @param Client $client      HTTP client
@@ -161,11 +161,15 @@ class HarvesterFactoryTest extends \PHPUnit\Framework\TestCase
         $client = $this->getMockClient();
         $client->expects($this->once())
             ->method('setOptions')
-            ->with($this->equalTo([
-                'sslverifypeer' => false, 
-                'timeout' => 60, 
-                'adapter' => \Laminas\Http\Client\Adapter\Proxy::class
-            ]));
+            ->with(
+                $this->equalTo(
+                    [
+                    'sslverifypeer' => false, 
+                    'timeout' => 60, 
+                    'adapter' => \Laminas\Http\Client\Adapter\Proxy::class
+                    ]
+                )
+            );
         $config = [
             'url' => 'http://localhost',
             'sslverifypeer' => false,
@@ -184,15 +188,19 @@ class HarvesterFactoryTest extends \PHPUnit\Framework\TestCase
         $client = $this->getMockClient();
         $client->expects($this->once())
             ->method('setOptions')
-            ->with($this->equalTo([
-                'timeout' => 60, 
-                'adapter' => \Laminas\Http\Client\Adapter\Proxy::class,
-                'proxy_host' => 'http://proxy.host',
-                'proxy_port' => 8080,
-                'proxy_user' => 'alice',
-                'proxy_pass' => 'foobar',
-                'proxy_auth' => \Laminas\Http\Client::AUTH_BASIC
-            ]));
+            ->with(
+                $this->equalTo(
+                    [
+                    'timeout' => 60, 
+                    'adapter' => \Laminas\Http\Client\Adapter\Proxy::class,
+                    'proxy_host' => 'http://proxy.host',
+                    'proxy_port' => 8080,
+                    'proxy_user' => 'alice',
+                    'proxy_pass' => 'foobar',
+                    'proxy_auth' => \Laminas\Http\Client::AUTH_BASIC
+                    ]
+                )
+            );
         $config = [
             'url' => 'http://localhost',
             'dateGranularity' => 'mygranularity',

--- a/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
+++ b/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
@@ -161,11 +161,46 @@ class HarvesterFactoryTest extends \PHPUnit\Framework\TestCase
         $client = $this->getMockClient();
         $client->expects($this->once())
             ->method('setOptions')
-            ->with($this->equalTo(['sslverifypeer' => false, 'timeout' => 60]));
+            ->with($this->equalTo([
+                'sslverifypeer' => false, 
+                'timeout' => 60, 
+                'adapter' => 'Laminas\Http\Client\Adapter\Proxy'
+            ]));
         $config = [
             'url' => 'http://localhost',
             'sslverifypeer' => false,
             'dateGranularity' => 'mygranularity',
+        ];
+        $this->getHarvester('test', sys_get_temp_dir(), $config, $client);
+    }
+
+    /**
+     * Test the proxy configuration.
+     *
+     * @return void
+     */
+    public function testProxy()
+    {
+        $client = $this->getMockClient();
+        $client->expects($this->once())
+            ->method('setOptions')
+            ->with($this->equalTo([
+                'timeout' => 60, 
+                'adapter' => 'Laminas\Http\Client\Adapter\Proxy',
+                'proxy_host' => 'http://proxy.host',
+                'proxy_port' => 8080,
+                'proxy_user' => 'alice',
+                'proxy_pass' => 'foobar',
+                'proxy_auth' => \Laminas\Http\Client::AUTH_BASIC
+            ]));
+        $config = [
+            'url' => 'http://localhost',
+            'dateGranularity' => 'mygranularity',
+            'proxy_host' => 'http://proxy.host',
+            'proxy_port' => 8080,
+            'proxy_user' => 'alice',
+            'proxy_pass' => 'foobar',
+            'proxy_auth' => \Laminas\Http\Client::AUTH_BASIC
         ];
         $this->getHarvester('test', sys_get_temp_dir(), $config, $client);
     }

--- a/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
+++ b/tests/integration-tests/src/VuFindTest/OaiPmh/HarvesterFactoryTest.php
@@ -67,7 +67,7 @@ class HarvesterFactoryTest extends \PHPUnit\Framework\TestCase
      * Get harvester
      *
      * @param string $target      Name of source being harvested (used as directory
-     *                            name for storing harvested data inside $harvestRoot)
+     * name for storing harvested data inside $harvestRoot)
      * @param string $harvestRoot Root directory containing harvested data.
      * @param array  $config      Additional settings
      * @param Client $client      HTTP client


### PR DESCRIPTION
Sometimes the harvesting service works behind an HTTP proxy and therefore need to be able to communicate with the outer world trough it. Laminas provides a dedicated `Laminas\Http\Client\Adapter\Proxy` adapter for it. If no proxy settings are present, this adapter falls back to a default `Socket` adapter so there is no harm in setting it up for all connections.