### PR TITLE
Fix stripping of metadata tags from the harvested XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## Next Release - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Bug when stripping nested <metadata> tags.
+
 ## 5.5.0 - 2025-10-22
 
 ### Added

--- a/src/OaiPmh/RecordXmlFormatter.php
+++ b/src/OaiPmh/RecordXmlFormatter.php
@@ -294,7 +294,16 @@ class RecordXmlFormatter
 
         $raw = trim($recordObj->metadata->asXML());
 
-	$record = $raw;
+        // Extract the actual metadata from inside the <metadata></metadata> tags;
+        // there is probably a cleaner way to do this, but this simple method avoids
+        // the complexity of dealing with namespaces in SimpleXML.
+        //
+        // We should also apply global search and replace at this time, if
+        // applicable.
+        $record = $this->performGlobalReplace(
+            preg_replace('/(^<metadata[^\>]*>)|(<\/metadata>$)/', '', $raw)
+        );
+
         // Collect attributes (for proper namespace resolution):
         $metadataAttributes = $this->extractHigherLevelAttributes(
             $raw,

--- a/src/OaiPmh/RecordXmlFormatter.php
+++ b/src/OaiPmh/RecordXmlFormatter.php
@@ -250,7 +250,7 @@ class RecordXmlFormatter
         $attributes = [];
         preg_match_all(
             '/(^| )([^"]*"?[^"]*"|[^\']*\'?[^\']*\')/',
-            $extractedNs[1],
+            $extractedNs[1] ?? '',
             $attributes
         );
         $extractedAttributes = [];

--- a/src/OaiPmh/RecordXmlFormatter.php
+++ b/src/OaiPmh/RecordXmlFormatter.php
@@ -294,16 +294,7 @@ class RecordXmlFormatter
 
         $raw = trim($recordObj->metadata->asXML());
 
-        // Extract the actual metadata from inside the <metadata></metadata> tags;
-        // there is probably a cleaner way to do this, but this simple method avoids
-        // the complexity of dealing with namespaces in SimpleXML.
-        //
-        // We should also apply global search and replace at this time, if
-        // applicable.
-        $record = $this->performGlobalReplace(
-            preg_replace('/(^<metadata[^\>]*>)|(<\/metadata>$)/m', '', $raw)
-        );
-
+	$record = $raw;
         // Collect attributes (for proper namespace resolution):
         $metadataAttributes = $this->extractHigherLevelAttributes(
             $raw,

--- a/tests/unit-tests/src/VuFindTest/OaiPmh/RecordXmlFormatterTest.php
+++ b/tests/unit-tests/src/VuFindTest/OaiPmh/RecordXmlFormatterTest.php
@@ -29,6 +29,7 @@
 
 namespace VuFindTest\Harvest;
 
+use SimpleXMLElement;
 use VuFindHarvest\OaiPmh\RecordXmlFormatter;
 
 /**
@@ -54,10 +55,9 @@ class RecordXmlFormatterTest extends \PHPUnit\Framework\TestCase
      *
      * @return mixed
      */
-    protected function getProperty($object, $property)
+    protected function getProperty(object|string $object, string $property): mixed
     {
         $reflectionProperty = new \ReflectionProperty($object, $property);
-        $reflectionProperty->setAccessible(true);
         return $reflectionProperty->getValue($object);
     }
 
@@ -66,7 +66,7 @@ class RecordXmlFormatterTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testConfig()
+    public function testConfig(): void
     {
         $config = [
             'injectId' => 'idtag',
@@ -96,7 +96,7 @@ class RecordXmlFormatterTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testIdInjection()
+    public function testIdInjection(): void
     {
         $formatter = new RecordXmlFormatter(['injectId' => 'id']);
         $result = $formatter->format('foo', $this->getRecordFromFixture());
@@ -109,7 +109,7 @@ class RecordXmlFormatterTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testDateInjection()
+    public function testDateInjection(): void
     {
         $formatter = new RecordXmlFormatter(['injectDate' => 'datetest']);
         $result = $formatter
@@ -123,7 +123,7 @@ class RecordXmlFormatterTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testHeaderInjection()
+    public function testHeaderInjection(): void
     {
         $cfg = ['injectHeaderElements' => 'identifier'];
         $formatter = new RecordXmlFormatter($cfg);
@@ -140,7 +140,7 @@ class RecordXmlFormatterTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testSetSpecInjection()
+    public function testSetSpecInjection(): void
     {
         $formatter = new RecordXmlFormatter(['injectSetSpec' => 'setSpec']);
         $result = $formatter->format('foo', $this->getRecordFromFixture());
@@ -155,7 +155,7 @@ class RecordXmlFormatterTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testSetNameInjection()
+    public function testSetNameInjection(): void
     {
         $formatter = new RecordXmlFormatter(['injectSetName' => 'setName']);
 
@@ -182,7 +182,7 @@ class RecordXmlFormatterTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testMissingMetadataException()
+    public function testMissingMetadataException(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Unexpected missing record metadata.');
@@ -192,11 +192,35 @@ class RecordXmlFormatterTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test stripping nested metadata tags correctly.
+     *
+     * @return void
+     */
+    public function testNestedMetadataTags(): void
+    {
+        $xml = <<<XML
+            <oai>
+                <metadata>
+                    <metadata>
+                        <content />
+                    </metadata>
+                </metadata>
+            </oai>
+            XML;
+        $formatter = new RecordXmlFormatter();
+        $this->assertEquals(
+            '<metadata><content/></metadata>',
+            // remove whitespace to simplify assertion:
+            preg_replace('/\s/', '', $formatter->format('foo', simplexml_load_string($xml)))
+        );
+    }
+
+    /**
      * Test global search and replace.
      *
      * @return void
      */
-    public function testGlobalSearchAndReplace()
+    public function testGlobalSearchAndReplace(): void
     {
         $formatter = new RecordXmlFormatter(
             [
@@ -219,7 +243,7 @@ class RecordXmlFormatterTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testNamespaceCorrection()
+    public function testNamespaceCorrection(): void
     {
         $formatter = new RecordXmlFormatter();
         $result = $formatter->format(
@@ -236,7 +260,7 @@ class RecordXmlFormatterTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testNamespaceInsertionFromRecordTag()
+    public function testNamespaceInsertionFromRecordTag(): void
     {
         $formatter = new RecordXmlFormatter();
         $result = $formatter->format(
@@ -256,9 +280,9 @@ class RecordXmlFormatterTest extends \PHPUnit\Framework\TestCase
      * @param string $fixture Filename of fixture (inside fixture directory).
      * @param int    $i       Index of record to retrieve from fixture.
      *
-     * @return object
+     * @return SimpleXMLElement
      */
-    protected function getRecordFromFixture($fixture = 'marc.xml', $i = 0)
+    protected function getRecordFromFixture(string $fixture = 'marc.xml', int $i = 0): SimpleXMLElement
     {
         $xml = simplexml_load_file(__DIR__ . '/../../../../fixtures/' . $fixture);
         return $xml->ListRecords->record[$i];


### PR DESCRIPTION
Matching https://github.com/vufind-org/vufindharvest/issues/42

Test plan:
1. Point your VuFind local oai.ini file (/usr/local/vufind/local/harvest/oai.ini) at the demo.dspace.org site (as of June 2026 it is running stock DSpace 10).
- Example oai.ini setting in https://github.com/vufind-org/vufindharvest/issues/42

2. Run a harvest: cd $VUFIND_HOME/harvest;
php harvest_oai.php demo -v

3. Validate the generated XML files: cd  /usr/local/vufind/local/harvest/demo/
xmllint --noout <filename>.xml

4. Observe there is an invalid XML error

5. Open the XML file and notice there is no </metadata> tag at the bottom of the file, to match the one opening <metadata> tag at the top.

6. Try to import the generated XML file cd $VUFIND_HOME/harvest;
./batch-import-xsl.sh demo ../../vufind/local/import/dspace.properties

7. Notice the import fails

8. Apply this PR

9. Remove any remaining files in your demo local harvest folder: rm /usr/local/vufind/local/harvest/demo/*

10. Repeat steps 2, 3 and 4

11. Observe there is no invalid XML error now

12. Open the XML file and notice there are two </metadata> tags at the bottom of the file now. Matching the two opening tags at the top.

13. Repeat step 6 and notice the import is successful.

Sponsored-by: Auckland University of Technology, New Zealand